### PR TITLE
Added validation for the name field in the contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -37,6 +37,7 @@
                 class="form-control"
                 id="exampleInputEmail1"
                 aria-describedby="emailHelp"
+                pattern="^[A-Za-z ]+$"
               />
             </div>
             <div class="mb-3">


### PR DESCRIPTION
In the contact form, there is no validation for the name field, allowing users to enter alphabets ,numbers, special characters etc. To address this issue, I have added validation to allow only uppercase and lowercase alphabets, as well as spaces.